### PR TITLE
Fix #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,13 @@ var isNumeric=function(arg){
 var pads={
   pads:[] ,
   search: function(query, callback){
+    padManager.listAllPads(function(null_value, the_pads) {
+      pads._do_search(the_pads.padIDs, query, callback);
+    });
+  },
+  _do_search: function(pads, query, callback){
     logger.debug("Admin/Pad | Query is",query);
-    var pads=padManager.listAllPads().padIDs
-      , data={
+    var data={
         progress : 1
         , message: "Search done."
         , query: query


### PR DESCRIPTION
Split search function into search and _do_search. search calls listAllPads,
and when the result comes back, it calls _do_search. Then _do_search calls
the original callback.

Tested against etherpad-lite release 1.3 and release 1.2.12.
