### PR TITLE
Search pattern can occur later in pad-name

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ var pads={
     ;
     
     if(query["pattern"] != null && query["pattern"] != ''){
-      var pattern=query.pattern+"*";
+      var pattern="*"+query.pattern+"*";
       pattern=RegExp.quote(pattern);
       pattern=pattern.replace(/(\\\*)+/g,'.*');
       pattern="^"+pattern+"$";


### PR DESCRIPTION
Searching for `meeting` now not only matches names like

```
meeting-feb
```

But also

```
feb-meeting
```

And

```
g.x9VnLKRXzgSfjwZy$02-feb-meeting
```

(the latter kind of url’s produced when using Etherpad’s group functionality)

Thanks to @latsami for pointing out the solution
