### PR TITLE
made socket.io path relative to the base url

### DIFF
--- a/static/js/admin/pads.js
+++ b/static/js/admin/pads.js
@@ -14,7 +14,7 @@ exports.documentReady=function(hooks, context, cb){
   var room = url + "pluginfw/admin/pads";
   
   //connect
-  socket = io.connect(room, {resource : resource});
+  socket = io.connect(room, {path: baseURL + "socket.io", resource : resource});
 
   $('.search-results').data('query', {
     pattern: '',


### PR DESCRIPTION
I'm using etherpad behind a reverse proxy at a different path; the core is supporting this, but I had to tweak this plugin to play nice.